### PR TITLE
Refactor GitHub Actions workflow to update branch reference

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.ref }}
+          ref: publish
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4


### PR DESCRIPTION
This pull request includes a minor change to the `.github/workflows/dotnet.yml` file. The change modifies the `ref` parameter in the `actions/checkout` step to use the `publish` branch instead of the current GitHub reference.

* [`.github/workflows/dotnet.yml`](diffhunk://#diff-d5a2cea578a0446aad66faf31bf1076ae94c9916b1a3374e342272a6300e8344L19-R19): Changed the `ref` parameter from `${{ github.ref }}` to `publish` in the `actions/checkout` step.